### PR TITLE
Add attributes to pre tag

### DIFF
--- a/src/Markdig.Prism/PrismCodeBlockRenderer.cs
+++ b/src/Markdig.Prism/PrismCodeBlockRenderer.cs
@@ -39,7 +39,9 @@ namespace Markdig.Prism
             var code = ExtractSourceCode(node);
 
             renderer
-                .Write("<pre>")
+                .Write("<pre")
+                .WriteAttributes(attributes)
+                .Write(">")
                 .Write("<code")
                 .WriteAttributes(attributes)
                 .Write(">")


### PR DESCRIPTION
When using your plugin with Markdig and Prism I noticed that you only add the css class (.language-{languageCode}) to the code tag. But the pre tag, who is the parent tag from code, also needs this css class. 
Is it possible to approve and merge this PR or leave me some comment if this PR couldn't be merged?
This is my first PR to someone others project, so maybe I'm doing some things wrong? If so, please let me know. :-)