### PR TITLE
Escape resulting source code before wrapping

### DIFF
--- a/src/Markdig.Prism/Markdig.Prism.csproj
+++ b/src/Markdig.Prism/Markdig.Prism.csproj
@@ -8,7 +8,6 @@
     <Copyright>Copyright © 2020 Ilya Verbitskiy</Copyright>
     <PackageProjectUrl>https://github.com/ilich/Markdig.Prism</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ilich/Markdig.Prism</RepositoryUrl>
-    <RepositoryType></RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>markdown markdig</PackageTags>
     <PackageId>WebStoating.Markdig.Prism</PackageId>

--- a/src/Markdig.Prism/PrismCodeBlockRenderer.cs
+++ b/src/Markdig.Prism/PrismCodeBlockRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.Versioning;
 using System.Text;
+using System.Web;
 using Markdig.Parsers;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
@@ -37,13 +38,14 @@ namespace Markdig.Prism
             attributes.AddClass($"language-{languageCode}");
 
             var code = ExtractSourceCode(node);
+            var escapedCode = HttpUtility.HtmlEncode(code);
 
             renderer
                 .Write("<pre>")
                 .Write("<code")
                 .WriteAttributes(attributes)
                 .Write(">")
-                .Write(code)
+                .Write(escapedCode)
                 .Write("</code>")
                 .Write("</pre>");
         }


### PR DESCRIPTION
This change adds escaping for code blocks inside `<pre><code>` section to fix incorrect behavior with `<` and `>` inside code of any language.

Fixes #6 
