### PR TITLE
Support Prism unescaped markup plugin for HTML/XML syntaxes

### DIFF
--- a/src/Markdig.Prism/PrismCodeBlockRenderer.cs
+++ b/src/Markdig.Prism/PrismCodeBlockRenderer.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Versioning;
+﻿using System;
+using System.Linq;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Web;
 using Markdig.Parsers;
@@ -16,6 +18,11 @@ namespace Markdig.Prism
         {
             this.codeBlockRenderer = codeBlockRenderer ?? new CodeBlockRenderer();
         }
+
+        private readonly string[] xmlLikeLanguages = new[]
+        {
+            "xml", "xml-doc", "html"
+        };
 
         protected override void Write(HtmlRenderer renderer, CodeBlock node)
         {
@@ -36,18 +43,33 @@ namespace Markdig.Prism
 
             var attributes = new HtmlAttributes();
             attributes.AddClass($"language-{languageCode}");
-
+            
             var code = ExtractSourceCode(node);
             var escapedCode = HttpUtility.HtmlEncode(code);
 
-            renderer
-                .Write("<pre>")
-                .Write("<code")
-                .WriteAttributes(attributes)
-                .Write(">")
-                .Write(escapedCode)
-                .Write("</code>")
-                .Write("</pre>");
+            if (xmlLikeLanguages.Contains(languageCode))
+            {
+                // Support markup languages
+                // https://prismjs.com/plugins/unescaped-markup/
+                renderer
+                    .Write("<script type='text/plain'")
+                    .WriteAttributes(attributes)
+                    .Write(">")
+                    .Write(escapedCode)
+                    .Write("</script>");
+            }
+            else
+            {
+                renderer
+                    .Write("<pre>")
+                    .Write("<code")
+                    .WriteAttributes(attributes)
+                    .Write(">")
+                    .Write(escapedCode)
+                    .Write("</code>")
+                    .Write("</pre>");
+
+            }
         }
 
         protected string ExtractSourceCode(LeafBlock node)


### PR DESCRIPTION
This change allows rendering XML and HTML syntaxes as mentioned [here](https://prismjs.com/index.html): https://prismjs.com/index.html and [here](https://prismjs.com/plugins/unescaped-markup/).

A code block like the following:

```xml
<SomeXmlTag>Some XML Value</SomeXmlTag>
```

Would be not properly translated to HTML:
https://svelte.dev/repl/7320f29169f943318e38c4a8740b7f05?version=3.55.1